### PR TITLE
(fix)add stylelint-a11y to stylelintrc skeleton

### DIFF
--- a/closet/skeletons/.stylelintrc
+++ b/closet/skeletons/.stylelintrc
@@ -1,3 +1,6 @@
 {
-    "extends": "stylelint-config-recommended"
+    "extends": [
+        "stylelint-config-recommended"
+        "stylelint-a11y/recommended"
+    ]
 }


### PR DESCRIPTION
Add stylelint-a11y/recommended to .stylelintrc skeleton

fix #169