### PR TITLE
(feature) Add SASS config

### DIFF
--- a/closet/skeletons/.stylelintrc
+++ b/closet/skeletons/.stylelintrc
@@ -1,6 +1,11 @@
 {
-    "extends": [
-        "stylelint-config-recommended"
-        "stylelint-a11y/recommended"
-    ]
+  "extends": [
+    "stylelint-config-recommended",
+    "stylelint-a11y/recommended"
+  ],
+  "rules": {
+    "max-nesting-depth": 2,
+    "declaration-no-important": true,
+    "font-weight-notation": "named-where-possible"
+  }
 }

--- a/closet/skeletons/sass/.stylelintrc
+++ b/closet/skeletons/sass/.stylelintrc
@@ -1,3 +1,15 @@
 {
-    "extends": "stylelint-config-recommended-scss"
+  "extends": [
+    "stylelint-config-recommended",
+    "stylelint-config-sass-guidelines",
+    "stylelint-a11y/recommended"
+  ],
+  "plugins": [
+    "stylelint-scss"
+  ],
+  "rules": {
+    "max-nesting-depth": 2,
+    "declaration-no-important": true,
+    "font-weight-notation": "named-where-possible"
+  }
 }

--- a/lib/config-helpers/sass.js
+++ b/lib/config-helpers/sass.js
@@ -1,10 +1,41 @@
 const { writeFiles } = require("../fileUtils");
+const { prettierConfigFiles, prettierDependencies } = require("./format");
+
+const sassConfigFiles = ["sass/.stylelintrc", ".stylelintignore"];
+const sassDependencies = [
+  "stylelint",
+  "stylelint-a11y",
+  "stylelint-config-recommended",
+  "sass",
+  "node-sass-chokidar",
+  "stylelint-scss",
+  "stylelint-config-sass-guidelines",
+];
 
 sassTooling = {
-  addSassLint: () => {
-    writeFiles(["sass/.stylelintrc", ".stylelintignore"]);
-    return ["stylelint", "stylelint-scss", "stylelint-config-recommended-scss"];
+  /**
+   * Returns an array of SASS tool dependencies
+   * and writes the relevant config files to disk
+   * @param {Boolean} withPrettier - Whether or not to include prettier related config
+   * @returns Array of strings of relevant dependencies
+   */
+  addSass: (withPrettier) => {
+    let configFiles = sassConfigFiles;
+    let dependencies = sassDependencies;
+
+    if (withPrettier) {
+      configFiles = configFiles.concat(prettierConfigFiles);
+      dependencies = dependencies.concat(prettierDependencies);
+    }
+
+    writeFiles(configFiles);
+
+    return dependencies;
   },
 };
 
-module.exports = sassTooling;
+module.exports = {
+  sassConfigFiles,
+  sassDependencies,
+  sassTooling,
+};

--- a/lib/config-helpers/sass.test.js
+++ b/lib/config-helpers/sass.test.js
@@ -1,0 +1,72 @@
+const fs = require("fs");
+const mock = require("mock-fs");
+
+const { sassConfigFiles, sassDependencies, sassTooling } = require("./sass");
+const { prettierConfigFiles, prettierDependencies } = require("./format");
+
+const defaultFiles = {
+  "closet/skeletons": {
+    sass: {
+      ".stylelintrc": "{}",
+    },
+    ".stylelintignore": "{}",
+  },
+};
+const withPrettierFiles = {
+  "closet/skeletons": {
+    sass: {
+      ".stylelintrc": "{}",
+    },
+    ".stylelintignore": "{}",
+    ".prettierrc": "{}",
+  },
+};
+
+describe("sassTooling.addSass", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("returns an array with the default dependencies as strings", async () => {
+    mock(defaultFiles);
+
+    let dependencies = await sassTooling.addSass();
+    expect(dependencies).toStrictEqual(sassDependencies);
+  });
+
+  it('"returns an array with the default and prettier dependencies as strings"', async () => {
+    mock(withPrettierFiles);
+
+    let dependencies = await sassTooling.addSass(true);
+
+    expect(dependencies).toStrictEqual(
+      sassDependencies.concat(prettierDependencies)
+    );
+  });
+
+  it("writes skeletons to disk", async () => {
+    mock(defaultFiles);
+
+    sassTooling.addSass();
+
+    sassConfigFiles.forEach((skeleton) => {
+      skeleton = skeleton.substr(skeleton.lastIndexOf("/") + 1);
+      expect(fs.statSync(skeleton).isFile()).toBe(true);
+    });
+  });
+
+  it("writes default and prettier skeletons to disk", async () => {
+    mock(withPrettierFiles);
+
+    sassTooling.addSass(true);
+
+    sassConfigFiles.forEach((skeleton) => {
+      skeleton = skeleton.substr(skeleton.lastIndexOf("/") + 1);
+      expect(fs.statSync(skeleton).isFile()).toBe(true);
+    });
+
+    prettierConfigFiles.forEach((skeleton) => {
+      expect(fs.statSync(skeleton).isFile()).toBe(true);
+    });
+  });
+});

--- a/lib/fileUtils.js
+++ b/lib/fileUtils.js
@@ -8,7 +8,7 @@ const SKELETON_CLOSET = "../closet/skeletons/";
 
 /**
  * Load the relevant skeleton and return its file contents
- * @param {String} skeleton - The skelton filename
+ * @param {String} skeleton - Relative path to the skeleton in `SKELETON_CLOSET`
  * @returns the file contents
  */
 function getFileContents(skeleton) {
@@ -46,10 +46,11 @@ async function writeFiles(skeletons) {
       }
     }
   } catch (error) {
-    signale.error(`Error while writing file: ${error.message}`);
+    signale.error(`Error in fileUtils: ${error.message}`);
   }
 }
 
 module.exports = {
+  getFileContents,
   writeFiles,
 };

--- a/lib/fill-catacomb.js
+++ b/lib/fill-catacomb.js
@@ -5,6 +5,7 @@ const { getConfig } = require("./config");
 
 const { cssTooling } = require("./config-helpers/css");
 const { formatTooling } = require("./config-helpers/format");
+const { sassTooling } = require("./config-helpers/sass");
 
 async function fillCatacomb() {
   const calaveraConfig = await getConfig();
@@ -23,6 +24,9 @@ async function fillCatacomb() {
     switch (config) {
       case "css":
         dependecies = dependecies.concat(cssTooling.addLinting(withPrettier));
+        break;
+      case "sass":
+        dependecies = dependecies.concat(sassTooling.addSass(withPrettier));
         break;
       case "prettier":
         let prettierDependencies = await formatTooling.addPrettier();


### PR DESCRIPTION
Adds SASS config. A user can now add SAS to their project via:

"calavera": {
  "sass": true
}

fix #172