### PR TITLE
(fix) programatically add required prettier config to stylelintrc

### DIFF
--- a/lib/config-helpers/css.js
+++ b/lib/config-helpers/css.js
@@ -24,7 +24,7 @@ cssTooling = {
       dependencies = dependencies.concat(prettierDependencies);
     }
 
-    writeFiles(configFiles);
+    writeFiles(configFiles, { withPrettier });
 
     return dependencies;
   },

--- a/lib/config-helpers/css.test.js
+++ b/lib/config-helpers/css.test.js
@@ -12,11 +12,12 @@ const defaultFiles = {
 };
 const withPrettierFiles = {
   "closet/skeletons/": {
-    ".stylelintrc": "{}",
+    ".stylelintrc": `{"extends":["stylelint-a11y/recommended"]}`,
     ".stylelintignore": "{}",
     ".prettierrc": "{}",
   },
 };
+const expectedFileContents = `{"extends":["stylelint-a11y/recommended","stylelint-prettier/recommended"]}`;
 
 describe("cssTooling.addLinting", () => {
   afterEach(() => {
@@ -61,5 +62,14 @@ describe("cssTooling.addLinting", () => {
     prettierConfigFiles.forEach((skeleton) => {
       expect(fs.statSync(skeleton).isFile()).toBe(true);
     });
+  });
+
+  it("writes the .stylelintrc with the addition of the Prettier config option", async () => {
+    mock(withPrettierFiles);
+
+    await cssTooling.addLinting(true);
+
+    const stylelintConfig = fs.readFileSync(".stylelintrc", "utf-8");
+    expect(stylelintConfig).toStrictEqual(expectedFileContents);
   });
 });

--- a/lib/config-helpers/sass.js
+++ b/lib/config-helpers/sass.js
@@ -28,7 +28,7 @@ sassTooling = {
       dependencies = dependencies.concat(prettierDependencies);
     }
 
-    writeFiles(configFiles);
+    writeFiles(configFiles, { withPrettier });
 
     return dependencies;
   },

--- a/lib/config-helpers/sass.test.js
+++ b/lib/config-helpers/sass.test.js
@@ -15,12 +15,13 @@ const defaultFiles = {
 const withPrettierFiles = {
   "closet/skeletons": {
     sass: {
-      ".stylelintrc": "{}",
+      ".stylelintrc": `{"extends":["stylelint-a11y/recommended"]}`,
     },
     ".stylelintignore": "{}",
     ".prettierrc": "{}",
   },
 };
+const expectedFileContents = `{"extends":["stylelint-a11y/recommended","stylelint-prettier/recommended"]}`;
 
 describe("sassTooling.addSass", () => {
   afterEach(() => {
@@ -68,5 +69,14 @@ describe("sassTooling.addSass", () => {
     prettierConfigFiles.forEach((skeleton) => {
       expect(fs.statSync(skeleton).isFile()).toBe(true);
     });
+  });
+
+  it("writes the .stylelintrc with the addition of the Prettier config option", async () => {
+    mock(withPrettierFiles);
+
+    await sassTooling.addSass(true);
+
+    const stylelintConfig = fs.readFileSync(".stylelintrc", "utf-8");
+    expect(stylelintConfig).toStrictEqual(expectedFileContents);
   });
 });

--- a/lib/fileUtils.js
+++ b/lib/fileUtils.js
@@ -7,6 +7,20 @@ const signale = require("signale");
 const SKELETON_CLOSET = "../closet/skeletons/";
 
 /**
+ * Adds an extends entry to `.stylelintrc` for Prettier
+ * @param {String} fileContents - `.stylelintrc` file contents
+ * @returns `fileContents` with Prettier config added
+ */
+function addPrettierToStylelintrc(fileContents) {
+  const json = JSON.parse(fileContents);
+  const stylelintPrettierConfig = "stylelint-prettier/recommended";
+
+  json.extends.push(stylelintPrettierConfig);
+
+  return JSON.stringify(json);
+}
+
+/**
  * Load the relevant skeleton and return its file contents
  * @param {String} skeleton - Relative path to the skeleton in `SKELETON_CLOSET`
  * @returns the file contents
@@ -27,23 +41,21 @@ function getFileContents(skeleton) {
 /**
  * Writes an Array of skeleton files to the root of the project
  * @param {Array} skeletons - The Array of skeleton filenames
+ * @param {Object} [writeConfig] - An optional object with file write settings
  */
-async function writeFiles(skeletons) {
+async function writeFiles(skeletons, writeConfig) {
   try {
     for (let skeleton of skeletons) {
-      const fileContents = getFileContents(skeleton);
+      const isStylelintrc = skeleton.indexOf(".stylelintrc");
+      let fileContents = getFileContents(skeleton);
 
-      // issue and pr templates are written to a different directory
-      if (
-        skeleton === "ISSUE_TEMPLATE.md" ||
-        skeleton === "PULL_REQUEST_TEMPLATE.md"
-      ) {
-        fse.outputFileSync("./.github/" + skeleton, fileContents);
-      } else {
-        // ensure we always write these files to the project root
-        skeleton = skeleton.substr(skeleton.lastIndexOf("/") + 1);
-        fse.outputFileSync("./" + skeleton, fileContents);
+      if (isStylelintrc > -1 && writeConfig && writeConfig.withPrettier) {
+        fileContents = addPrettierToStylelintrc(fileContents);
       }
+
+      // ensure we always write these files to the project root
+      skeleton = skeleton.substr(skeleton.lastIndexOf("/") + 1);
+      fse.outputFileSync("./" + skeleton, fileContents);
     }
   } catch (error) {
     signale.error(`Error in fileUtils: ${error.message}`);


### PR DESCRIPTION
Add "stylelint-prettier/recommended" to the .stylelintrc config when
using Prettier with either the CSS or SASS config options.

fix #175