### PR TITLE
(fix) incorrect dependencies for prettier with stylelint

### DIFF
--- a/lib/config-helpers/css.js
+++ b/lib/config-helpers/css.js
@@ -1,5 +1,8 @@
 const { writeFiles } = require("../fileUtils");
-const { prettierConfigFiles, prettierDependencies } = require("./format");
+const {
+  prettierConfigFiles,
+  prettierWithStylelintDependencies,
+} = require("./format");
 
 const cssConfigFiles = [".stylelintrc", ".stylelintignore"];
 const cssDependencies = [
@@ -21,7 +24,7 @@ cssTooling = {
 
     if (withPrettier) {
       configFiles = configFiles.concat(prettierConfigFiles);
-      dependencies = dependencies.concat(prettierDependencies);
+      dependencies = dependencies.concat(prettierWithStylelintDependencies);
     }
 
     writeFiles(configFiles, { withPrettier });

--- a/lib/config-helpers/css.test.js
+++ b/lib/config-helpers/css.test.js
@@ -2,7 +2,10 @@ const fs = require("fs");
 const mock = require("mock-fs");
 
 const { cssConfigFiles, cssDependencies, cssTooling } = require("./css");
-const { prettierConfigFiles, prettierDependencies } = require("./format");
+const {
+  prettierConfigFiles,
+  prettierWithStylelintDependencies,
+} = require("./format");
 
 const defaultFiles = {
   "closet/skeletons/": {
@@ -36,7 +39,7 @@ describe("cssTooling.addLinting", () => {
 
     let dependencies = await cssTooling.addLinting(true);
     expect(dependencies).toStrictEqual(
-      cssDependencies.concat(prettierDependencies)
+      cssDependencies.concat(prettierWithStylelintDependencies)
     );
   });
 

--- a/lib/config-helpers/format.js
+++ b/lib/config-helpers/format.js
@@ -2,6 +2,11 @@ const { writeFiles } = require("../fileUtils");
 
 const prettierConfigFiles = [".prettierrc"];
 const prettierDependencies = ["prettier"];
+const prettierWithStylelintDependencies = [
+  "prettier",
+  "stylelint-config-prettier",
+  "stylelint-prettier",
+];
 
 formatTooling = {
   addPrettier: async () => {
@@ -13,5 +18,6 @@ formatTooling = {
 module.exports = {
   prettierConfigFiles,
   prettierDependencies,
+  prettierWithStylelintDependencies,
   formatTooling,
 };

--- a/lib/config-helpers/sass.js
+++ b/lib/config-helpers/sass.js
@@ -1,5 +1,8 @@
 const { writeFiles } = require("../fileUtils");
-const { prettierConfigFiles, prettierDependencies } = require("./format");
+const {
+  prettierConfigFiles,
+  prettierWithStylelintDependencies,
+} = require("./format");
 
 const sassConfigFiles = ["sass/.stylelintrc", ".stylelintignore"];
 const sassDependencies = [
@@ -25,7 +28,7 @@ sassTooling = {
 
     if (withPrettier) {
       configFiles = configFiles.concat(prettierConfigFiles);
-      dependencies = dependencies.concat(prettierDependencies);
+      dependencies = dependencies.concat(prettierWithStylelintDependencies);
     }
 
     writeFiles(configFiles, { withPrettier });

--- a/lib/config-helpers/sass.test.js
+++ b/lib/config-helpers/sass.test.js
@@ -2,7 +2,10 @@ const fs = require("fs");
 const mock = require("mock-fs");
 
 const { sassConfigFiles, sassDependencies, sassTooling } = require("./sass");
-const { prettierConfigFiles, prettierDependencies } = require("./format");
+const {
+  prettierConfigFiles,
+  prettierWithStylelintDependencies,
+} = require("./format");
 
 const defaultFiles = {
   "closet/skeletons": {
@@ -41,7 +44,7 @@ describe("sassTooling.addSass", () => {
     let dependencies = await sassTooling.addSass(true);
 
     expect(dependencies).toStrictEqual(
-      sassDependencies.concat(prettierDependencies)
+      sassDependencies.concat(prettierWithStylelintDependencies)
     );
   });
 


### PR DESCRIPTION
When using Prettier with Stylelint we need the following additional
dependencies installed:

"stylelint-config-prettier"
"stylelint-prettier"

fix #178