### PR TITLE
(enhancement) add yarn support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npx project-calavera
 
 This will add the required dot-files to your project. Once the command completes, it will output the command you should run to install the required dependencies:
 
-> NOTE: Calavera by defaults prints the command for the Yarn dependency manager. If you prefer `NPM`, you can specify it as part of your Calavera config, for example:
+> NOTE: Calavera by default prints the command for the Yarn dependency manager. If you prefer `NPM`, you can specify it as part of your Calavera config, for example:
 >
 > ```
 > "calavera": {

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A simple starting skeleton for common web projects. Bring your own frameworks.
 
 ### Prerequisites
 
-To start with, you will need to have Nodejs installed. You can find instructions on the [Nodejs website](https://nodejs.org/en/).
+To start with, you will need to have Nodejs installed. You can find instructions on the [Nodejs website](https://nodejs.org/).
 
 Your next stop is to ensure that your project has a `package.json` file in the root of the project. If your project does not already have one, you can create one using the `npm init` or `yarn init` command from your command line/terminal.
 
@@ -42,10 +42,22 @@ Run the following from the root of your project:
 npx project-calavera
 ```
 
-This will add the required dot-files needed. Once the command completes, it will output the `npm`(`yarn` comming soon 😁) command you should run to install the required dependencies:
+This will add the required dot-files to your project. Once the command completes, it will output the command you should run to install the required dependencies:
+
+> NOTE: Calavera by defaults prints the command for the Yarn dependency manager. If you prefer `NPM`, you can specify it as part of your Calavera config, for example:
+>
+> ```
+> "calavera": {
+>    "manager": "npm",
+>    "eslint": true,
+>    "prettier": true
+> }
+> ```
 
 ```
 Run the following command to install your dependencies: npm i -D --save-exact babel-cli babel-preset-env eslint
 ```
 
-Copy/paste an run the command. Once complete, you are of to the races.
+Copy, paste and run the command in your terminal. Once complete, you are of to the races.
+
+Make something awesome! 💀

--- a/lib/fill-catacomb.js
+++ b/lib/fill-catacomb.js
@@ -19,7 +19,8 @@ async function fillCatacomb() {
   }
 
   const configKeys = Object.keys(calaveraConfig);
-  let dependecies = [];
+  let dependencies = [];
+  let manager = "yarn";
   let withPrettier = false;
 
   /* If there is more than one entry in calaveraConfig, determine
@@ -44,19 +45,22 @@ async function fillCatacomb() {
   for (let config in calaveraConfig) {
     switch (config) {
       case "css":
-        dependecies = dependecies.concat(cssTooling.addLinting(withPrettier));
+        dependencies = dependencies.concat(cssTooling.addLinting(withPrettier));
         break;
       case "sass":
-        dependecies = dependecies.concat(sassTooling.addSass(withPrettier));
+        dependencies = dependencies.concat(sassTooling.addSass(withPrettier));
         break;
       case "eslint":
-        dependecies = dependecies.concat(
+        dependencies = dependencies.concat(
           eslintTooling.addLinting(withPrettier)
         );
         break;
+      case "manager":
+        manager = config;
+        break;
       case "prettier":
         let prettierDependencies = await formatTooling.addPrettier();
-        dependecies = dependecies.concat(prettierDependencies);
+        dependencies = dependencies.concat(prettierDependencies);
         break;
       default:
         signale.error(`No configuration or skeleton match found for ${config}`);
@@ -65,7 +69,7 @@ async function fillCatacomb() {
   }
 
   // Log next steps information to the terminal.
-  complete(calaveraConfig, dependecies);
+  complete(manager, dependencies);
 }
 
 module.exports = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,44 +5,32 @@ const path = require("path");
 const signale = require("signale");
 
 /**
- * Takes an Array of dependencies and returns the npm command to run
- * in order to install all required dependencies.
- * @param {Array} dependecies - The array of dependencies that needs to be installed
- * @returns {String} For example: npm i -D --save-exact eslint stylelint
- */
-function getNPMInstallCmd(dependencies) {
-  return `npm i -D --save-exact ${dependencies.join(" ")}`;
-}
-
-/**
- * Takes an Array of dependencies and returns the yarn command to run
- * in order to install all required dependencies.
- * @param {Array} dependecies - The array of dependencies that needs to be installed
+ * Takes an Array of dependencies and returns the install command for
+ * the specified package manager
+ * @param {String} manager - The depenency manager - One of `yarn` or `npm`
+ * @param {Array} dependencies - The array of dependencies that needs to be installed
  * @returns {String} For example: yarn eslint stylelint --dev
  */
-function getYarnInstallCmd(dependencies) {
-  return `yarn ${dependencies.join(" ")} --dev`;
+function getInstallCmd(manager, dependencies) {
+  const npmCmd = `npm i -D --save-exact ${dependencies.join(" ")}`;
+  const yarnCmd = `yarn ${dependencies.join(" ")} --dev`;
+
+  return manager === "yarn" ? yarnCmd : npmCmd;
 }
 
 /**
  * Called when Calavera has written all skeletons. Logs
  * next steps information to the terminal.
- * @param {Object} calaveraConfig - The current calaveraConfig
- * @param {Array} dependecies - The array of dependencies that needs to be installed
+ * @param {String} manager - The depenency manager - One of `yarn` or `npm`
+ * @param {Array} dependencies - The array of dependencies that needs to be installed
  */
-function complete(calaveraConfig, dependecies) {
+function complete(manager, dependencies) {
   signale.success("[Calavera] Skeletons written to project successfully");
 
-  /* Only output the dependency info if there are more than one entry in
-       calaveraConfig or, if there is only one, be sure that it is not colab.
-       This is because the colab configuration does not require the installation
-       of any dependencies */
-  if (Object.keys(calaveraConfig)[0] !== "colab") {
-    const INSTALL_CMD = getNPMInstallCmd(dependecies);
-    signale.info(
-      `[Calavera] Run the following command to install dependencies: ${INSTALL_CMD}`
-    );
-  }
+  const INSTALL_CMD = getInstallCmd(manager, dependencies);
+  signale.info(
+    `[Calavera] Run the following command to install dependencies: ${INSTALL_CMD}`
+  );
 }
 
 async function loadPackageJson() {


### PR DESCRIPTION
Add support for specifying your preferred dependency manager.

Before the install command would always be an `npm` command. This
changes the default to `yarn` but also allows you to specify npm
via the Calavera config, for example:

```
"calavera": {
  "manager": "npm",
  "prettier": true
}
```

fix #167